### PR TITLE
Switch to GitHub image hosting

### DIFF
--- a/img_urls.toml
+++ b/img_urls.toml
@@ -1,5 +1,5 @@
 [img_urls]
-tsp_header = 'https://i.imgur.com/y6LZEVr.png'
-tsp_flag = 'https://i.imgur.com/Z5Jco7z.png'
-gov_header = 'https://i.imgur.com/PFcKS2K.png'
-tsp_footer = 'https://i.imgur.com/3NOkgsk.png'
+tsp_header = 'https://raw.githubusercontent.com/TheSouthPacific/tsp-graphics/7fc3611e20045bb8a03bf9cb6f5207820864f74f/regional/tsp-dispatch.png'
+tsp_flag = 'https://raw.githubusercontent.com/TheSouthPacific/tsp-graphics/7fc3611e20045bb8a03bf9cb6f5207820864f74f/regional/flag.png'
+gov_header = 'https://raw.githubusercontent.com/TheSouthPacific/tsp-graphics/7fc3611e20045bb8a03bf9cb6f5207820864f74f/regional/government-dispatch.png'
+tsp_footer = 'https://raw.githubusercontent.com/TheSouthPacific/tsp-graphics/7fc3611e20045bb8a03bf9cb6f5207820864f74f/regional/footer-dispatch.png'


### PR DESCRIPTION
Imgur is no longer available to users in the United Kingdom ([source](https://help.imgur.com/hc/en-us/articles/41592665292443-Imgur-access-in-the-United-Kingdom)). This PR migrates to images on the raw.githubusercontent.com domain.

After this is merged, I can also go ahead and update the dispatch master config sheet